### PR TITLE
Passes namespace of robot to the virtual joy as a paramter

### DIFF
--- a/docker/generic/docker-compose.yaml
+++ b/docker/generic/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
             - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
             - CYCLONEDDS_URI=/home/user/ros/launch_content/cyclone_profile.xml  
         network_mode: "host"
-        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch server.launch.py'        
+        command: bash -c 'cd /home/user/ros/launch_content; ros2 launch server.launch.py edu_robot_namespace:=${EDU_ROBOT_NAMESPACE}'        
         # command: bash -c 'ros2 run edu_virtual_joy virtual_joy --ros-args -r __ns:=${EDU_ROBOT_NAMESPACE}'
         volumes:
             - './launch_content:/home/user/ros/launch_content:r'


### PR DESCRIPTION
Launch file expects a namespace. Otherwise this error will occur:
`eduart-virtual-joy-0.2.0  | malformed launch argument 'edu_robot', expected format '<name>:=<value>'`

Tested on Eduard-IPC